### PR TITLE
apply common sense

### DIFF
--- a/app/views/users/_sidebar.html.haml
+++ b/app/views/users/_sidebar.html.haml
@@ -38,8 +38,8 @@
       %li.list-group-item.text-muted
         = f_form_for @user, remote: true do |f|
           .center
-            = f.label "Show dagschotel on koelkast"
-            = f.check_box :quickpay_hidden, skip_label: true, data: { switch: true, offText: "show", onText: "hide" }
+            = f.label "Hide dagschotel on koelkast?"
+            = f.check_box :quickpay_hidden, skip_label: true, data: { switch: true, offText: "no", onText: "yes" }
       %li.list-group-item.text-muted
         = f_form_for @user do |f|
           = f.file_field :avatar, skip_label: true


### PR DESCRIPTION
Because really, with a label where the answer to "Show?" is positive, should the onText really be "hide"?

Also "show" and "hide" are verbs, which might suggest clicking them will apply that verb, which it won't.

Also actually the database column should be inverted and called "quickpay_visible" because we are all looking at the bright side of life, but that's more work.
