### PR TITLE
Improve performance

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -21,7 +21,7 @@ class OrdersController < ApplicationController
   # Create a new order page
   # GET /products/new
   def new
-    @products = Product.all.for_sale.order(:name)
+    @products = Product.all.for_sale.order(:name).includes(:barcodes)
     @categories = Product.categories
     @order.products << @products
   end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -19,7 +19,7 @@ class OrdersController < ApplicationController
   skip_before_action :set_user!
 
   # Create a new order page
-  # GET /products/new
+  # GET /users/{username}/orders/new
   def new
     @products = Product.all.for_sale.order(:name).includes(:barcodes)
     @categories = Product.categories

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -5,6 +5,9 @@
       <!-- Title -->
       <div class="order-new-actions-title">
         <% if current_user.koelkast %>
+          <div class="back is-size-5">
+            <%= link_to "Go back", root_path %>
+          </div>
           Place an order for <%= @user.name %>
         <% else %>
           Place an order

--- a/app/views/products/_list.html.erb
+++ b/app/views/products/_list.html.erb
@@ -4,8 +4,6 @@
 <% compact = compact || false %>
 <% compact_mobile = compact_mobile || false %>
 
-<% product_wrapper_class = "column #{compact ? 'is-12 py-1' : ' is-4-tablet is-3-desktop is-2-widescreen'} #{compact_mobile ? 'is-12-mobile py-1-mobile' : ''}" %>
-
 <div x-data="setupProductList()" x-init="$watch('productSearch', () => onProductSearchChange())">
 
   <!-- Header -->
@@ -46,39 +44,40 @@
 
     <!-- All -->
     <div class="columns is-multiline" x-show="isActiveTab('all')">
-        <% @products.each do |product| %>
-          <div
-            class="<%= product_wrapper_class %>"
-            x-show="shouldShowProduct('<%= escape_javascript product.name %>')"
-          >
-            <%= render product, details: details, actions: actions, compact: compact, compact_mobile: compact_mobile %>
-          </div>
-        <% end %>
+      <%= render partial: "products/product",
+        collection: @products,
+        as: :product,
+        cache: true,
+        locals: {
+          search: true,
+          details: details,
+          actions: actions,
+          compact: compact,
+          compact_mobile: compact_mobile
+        }
+      %>
     </div>
 
     <!-- Categories -->
     <% if display_categories %>
-      <% @categories.each do |o, i| %>
-        <div class="columns is-multiline" x-show="isActiveTab('<%= o %>')" x-cloak>
-
-          <!-- Placeholder -->
-          <% if @products.where(category: i).count == 0 %>
-            <div class="column placeholder">
-              No items in this category.
-            </div>
-          <% end %>
-
-          <% @products.where(category: i).each do |product| %>
-            <div
-              class="<%= product_wrapper_class  %>"
-              x-show="shouldShowProduct('<%= escape_javascript product.name %>')"
-            >
-              <%= render product, details: details, actions: actions, compact: compact, compact_mobile: compact_mobile %>
-            </div>
-          <% end %>
+      <% @categories.each do |category, index| %>
+        <div class="columns is-multiline" x-show="isActiveTab('<%= category %>')" x-cloak>
+          <%= render partial: "products/product",
+            collection: @products.where(category: index),
+            as: :product,
+            cache: true,
+            locals: {
+              search: true,
+              details: details,
+              actions: actions,
+              compact: compact,
+              compact_mobile: compact_mobile
+            }
+          %>
         </div>
       <% end %>
     <% end %>
+
 
     <!--
     No search results placeholder

--- a/app/views/products/_list.html.erb
+++ b/app/views/products/_list.html.erb
@@ -19,10 +19,10 @@
             </li>
 
             <!-- Categories -->
-              <% @categories.each do |o, i| %>
-                <li x-bind:class="isActiveTab('<%= o %>') ? 'is-active' : ''">
-                  <a x-on:click="setActiveTab('<%= o %>')">
-                    <%= o.titleize %>
+              <% @categories.each do |category, index| %>
+                <li x-bind:class="isActiveTab('<%= category %>') ? 'is-active' : ''">
+                  <a x-on:click="setActiveTab('<%= category %>')">
+                    <%= category.titleize %>
                   </a>
                 </li>
               <% end %>
@@ -41,9 +41,7 @@
 
   <!-- Content -->
   <div class="tabs-content">
-
-    <!-- All -->
-    <div class="columns is-multiline" x-show="isActiveTab('all')">
+    <div class="columns is-multiline">
       <%= render partial: "products/product",
         collection: @products,
         as: :product,
@@ -58,26 +56,6 @@
       %>
     </div>
 
-    <!-- Categories -->
-    <% if display_categories %>
-      <% @categories.each do |category, index| %>
-        <div class="columns is-multiline" x-show="isActiveTab('<%= category %>')" x-cloak>
-          <%= render partial: "products/product",
-            collection: @products.where(category: index),
-            as: :product,
-            cache: true,
-            locals: {
-              search: true,
-              details: details,
-              actions: actions,
-              compact: compact,
-              compact_mobile: compact_mobile
-            }
-          %>
-        </div>
-      <% end %>
-    <% end %>
-
 
     <!--
     No search results placeholder
@@ -85,7 +63,7 @@
     The value of "shouldShowProduct" is a hack to display the placeholder when no entries match the given search query.
     It checks if there is no match in a string concatenation of all product names.
     -->
-    <div class="placeholder" x-show="!shouldShowProduct('<%= escape_javascript @products.map(&:name).join %>')" x-cloak>
+    <div class="placeholder" x-show="!shouldShowProduct('<%= escape_javascript @products.map(&:name).join %>', null)" x-cloak>
       No products found matching that query.
     </div>
   </div>
@@ -119,10 +97,23 @@ function setupProductList() {
     },
 
     /**
-     * If a specific product should be shown, based on if the name matches the search field value.
+     * If a specific product should be shown, based on:
+     * * if it matches the category
+     * * if the name matches the search field value.
      */
-    shouldShowProduct(name) {
-      return name.toLowerCase().includes(this.productSearch.toLowerCase());
+    shouldShowProduct(name, category) {
+
+      // If the product doesn't match the category, return false
+      if (category && this.productTab !== "all" && this.productTab !== category) {
+        return false;
+      }
+
+      // If the product doesn't match the search query, return false
+      if (this.productSearch && !name.toLowerCase().includes(this.productSearch.toLowerCase())) {
+        return false;
+      }
+
+      return true;
     },
 
     /**

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -4,7 +4,7 @@
 <% compact = compact || false %>
 <% compact_mobile = compact_mobile || false %>
 
-<% product_show = search ? "shouldShowProduct('#{escape_javascript product.name}')" : "true" %>
+<% product_show = search ? "shouldShowProduct('#{escape_javascript product.name}', '#{escape_javascript product.category}')" : "true" %>
 <% product_wrapper_class = "column #{compact ? 'is-12 py-1' : ' is-4-tablet is-3-desktop is-2-widescreen'} #{compact_mobile ? 'is-12-mobile py-1-mobile' : ''}" %>
 <% product_class = "products-item #{compact ? 'is-compact' : ''} #{compact_mobile ? 'is-compact-mobile' : ''}"  %>
 <% product_render = render "products/product_content",

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,45 +1,52 @@
 <% details = details || false %>
 <% actions = actions || [] %>
+<% search = search || false %>
 <% compact = compact || false %>
 <% compact_mobile = compact_mobile || false %>
+
+<% product_show = search ? "shouldShowProduct('#{escape_javascript product.name}')" : "true" %>
+<% product_wrapper_class = "column #{compact ? 'is-12 py-1' : ' is-4-tablet is-3-desktop is-2-widescreen'} #{compact_mobile ? 'is-12-mobile py-1-mobile' : ''}" %>
 <% product_class = "products-item #{compact ? 'is-compact' : ''} #{compact_mobile ? 'is-compact-mobile' : ''}"  %>
 <% product_render = render "products/product_content",
-    details: details,
-    actions: actions,
-    product: product,
-    compact: compact,
-    compact_mobile: compact_mobile %>
+  details: details,
+  actions: actions,
+  product: product,
+  compact: compact,
+  compact_mobile: compact_mobile
+%>
 
-<% if actions.include? "barcode:link" %>
 
+<div class="<%= product_wrapper_class %>" x-show="<%= product_show  %>">
   <!--
   Use when linking a new barcode to a specific product
   -->
-  <%=
-    button_to product_barcodes_path(product),
-    class: product_class,
-    data: { product: product.id, dismiss: :modal },
-    params: { "barcode[code]" => params[:barcode][:code] } do %>
-      <%= product_render %>
-  <% end %>
-<% elsif actions.include? "order:add" %>
+  <% if actions.include? "barcode:link" %>
+    <%=
+      button_to product_barcodes_path(product),
+      class: product_class,
+      data: { product: product.id, dismiss: :modal },
+      params: { "barcode[code]" => params[:barcode][:code] } do %>
+        <%= product_render %>
+    <% end %>
 
   <!--
   Use within the product select modal on the order page
   -->
-  <button
-    class="<%= product_class %>"
-    x-on:click.prevent="getOrderItem(<%= product.id %>).quantity++"
-    x-on:click="productsModalOpen = false"
-  >
-    <%= product_render %>
-  </button>
-<% else %>
+  <% elsif actions.include? "order:add" %>
+    <button
+      class="<%= product_class %>"
+      x-on:click.prevent="getOrderItem(<%= product.id %>).quantity++"
+      x-on:click="productsModalOpen = false"
+    >
+      <%= product_render %>
+    </button>
 
   <!--
   Use in all other places
   -->
-  <div class="<%= product_class %> products-item--not-clickable">
-    <%= product_render %>
-  </div>
-<% end %>
+  <% else %>
+    <div class="<%= product_class %> products-item--not-clickable">
+      <%= product_render %>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
* Improve performance of the new order page by fetching all barcodes in a single query, instead of a query for each product.
* Use partial collection instead of each-loop over every partial
* Render products in list only once, instead of for each category + global overview