### PR TITLE
Fix update product form errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ public/assets
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+/spec/test_files/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,7 @@ GEM
     puma (5.5.2)
       nio4r (~> 2.0)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-protection (2.2.0)
       rack
     rack-proxy (0.7.2)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -61,11 +61,11 @@ class ProductsController < ApplicationController
   def update
     # If the product was updated successfully
     # Otherwise, render the edit page again, which will show the errors
-    if @product.update!(product_params)
+    if @product.update(product_params)
       flash[:success] = "Product has been updated!"
       redirect_to products_path
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/spec/controllers/products_controller_spec.rb
+++ b/spec/controllers/products_controller_spec.rb
@@ -124,11 +124,9 @@ describe ProductsController, type: :controller do
 
     context "failed" do
       it "does not update attributes" do
-        old_price = product.price
         expect do
           put :update, params: { id: product, product: attributes_for(:invalid_product) }
-        end.to raise_error(ActiveRecord::RecordInvalid)
-        expect(product.reload.price).to eq(old_price)
+        end.not_to(change { product.reload.price })
       end
     end
   end


### PR DESCRIPTION
Fixes #168 

Cause is the `!` after `update`. `!` fails immediately (and abort everything), while not using `!` will just return `false`, so the `render :edit` was never executed. The unprocessable entity bit is because Turbo fails otherwise when reloading the page.

<img width="789" alt="image" src="https://user-images.githubusercontent.com/915130/171689167-08bdbfaa-54a0-46c3-b28d-ebdf4f00dcb4.png">
