### PR TITLE
Add foreign keys to Tap

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -13,7 +13,7 @@
 #  avatar_content_type :string
 #  avatar_file_size    :integer
 #  avatar_updated_at   :datetime
-#  category            :integer          default(0)
+#  category            :integer          default("food")
 #  stock               :integer          default(0), not null
 #  calories            :integer
 #  deleted             :boolean          default(FALSE)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,8 @@
 #  name                :string
 #  private             :boolean          default(FALSE)
 #  frecency            :integer          default(0), not null
-#  quickpay_hidden     :boolean
+#  quickpay_hidden     :boolean          default(FALSE)
+#  userkey             :string
 #
 
 class User < ApplicationRecord

--- a/db/migrate/20220725163014_add_foreign_keys.rb
+++ b/db/migrate/20220725163014_add_foreign_keys.rb
@@ -1,0 +1,15 @@
+class AddForeignKeys < ActiveRecord::Migration[6.1]
+  def change
+    # Actually use the "relational" part of the database.
+    add_foreign_key :barcodes, :products
+    add_foreign_key :order_items, :orders
+    add_foreign_key :order_items, :products
+    add_foreign_key :orders, :users
+    add_foreign_key :users, :products, column: :dagschotel_id
+
+    # Most foreign keys must not be null.
+    change_column_null :barcodes, :product_id, false
+    change_column_null :order_items, :order_id, false
+    change_column_null :orders, :user_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_04_203432) do
+ActiveRecord::Schema.define(version: 2022_07_25_163014) do
 
   create_table "barcodes", force: :cascade do |t|
     t.integer "product_id"
@@ -88,4 +88,9 @@ ActiveRecord::Schema.define(version: 2021_10_04_203432) do
     t.index ["orders_count"], name: "index_users_on_orders_count"
   end
 
+  add_foreign_key "barcodes", "products"
+  add_foreign_key "order_items", "orders"
+  add_foreign_key "order_items", "products"
+  add_foreign_key "orders", "users"
+  add_foreign_key "users", "products", column: "dagschotel_id"
 end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -13,7 +13,7 @@
 #  avatar_content_type :string
 #  avatar_file_size    :integer
 #  avatar_updated_at   :datetime
-#  category            :integer          default(0)
+#  category            :integer          default("food")
 #  stock               :integer          default(0), not null
 #  calories            :integer
 #  deleted             :boolean          default(FALSE)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -19,7 +19,8 @@
 #  name                :string
 #  private             :boolean          default(FALSE)
 #  frecency            :integer          default(0), not null
-#  quickpay_hidden     :boolean
+#  quickpay_hidden     :boolean          default(FALSE)
+#  userkey             :string
 #
 
 require "faker"

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -13,7 +13,7 @@
 #  avatar_content_type :string
 #  avatar_file_size    :integer
 #  avatar_updated_at   :datetime
-#  category            :integer          default(0)
+#  category            :integer          default("food")
 #  stock               :integer          default(0), not null
 #  calories            :integer
 #  deleted             :boolean          default(FALSE)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,7 +19,8 @@
 #  name                :string
 #  private             :boolean          default(FALSE)
 #  frecency            :integer          default(0), not null
-#  quickpay_hidden     :boolean
+#  quickpay_hidden     :boolean          default(FALSE)
+#  userkey             :string
 #
 
 require "webmock/rspec"


### PR DESCRIPTION
Actually use the "relational" part of the relational database.

When deploying/migrating this migration, we should be aware that it might fail, as the database might have become inconsistent. Some manual work (e.g. creating a "deleted product" and linking to it, deleting empty orders, ...) might be necessary.