### PR TITLE
Implement order API

### DIFF
--- a/app/views/orders/_order.html.erb
+++ b/app/views/orders/_order.html.erb
@@ -22,7 +22,7 @@
   <!-- Actions -->
   <td class="order-item-actions">
     <% if order.deletable %>
-      <%= button_to "Cancel order (until #{(order.created_at + Rails.application.config.call_api_after).strftime("%H:%M")})",
+      <%= button_to "Cancel order (until #{(order.deletable_until).strftime("%H:%M")})",
           user_order_path(@user, order),
           method: :delete,
           class: "button is-danger is-light",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
 
   # /users/...
   resources :users, only: [:show, :update] do
-    resources :orders, only: [:new, :create, :destroy] do
+    resources :orders, only: [:index, :new, :create, :destroy] do
       get :new_products, on: :collection
       post "/new" => "orders#new_update", on: :collection
     end

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: orders
+#
+#  id             :integer          not null, primary key
+#  user_id        :integer
+#  price_cents    :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  transaction_id :integer
+#
+
+describe OrdersController, type: :controller do
+  let(:user) { create :user }
+
+  before do
+    stub_request(:get, /.*/).to_return(status: 200, body: JSON.dump({ balance: 12_345 }))
+    sign_in user
+  end
+
+  ##########
+  #  INDEX  #
+  ##########
+
+  describe "INDEX orders" do
+    let!(:final_orders) do
+      create_list :order, 2, user: user, created_at: Time.zone.now - Rails.application.config.call_api_after - 5.minutes
+    end
+    let!(:pending_orders) { create_list :order, 2, user: user, created_at: Time.zone.now }
+
+    it "gets all orders for user without filter" do
+      # Create some orders for another user
+      other_user = create :user
+      create_list :order, 2, user: other_user
+
+      get :index, params: { user_id: user }, format: :json
+
+      expect(response).to have_http_status(:ok)
+      expected_result = JSON.parse(final_orders.concat(pending_orders).to_json(include: :products,
+                                                                               methods: :deletable_until))
+      actual_result = JSON.parse(response.body)
+      expect(actual_result).to match_array(expected_result)
+    end
+
+    it "returns pending orders when requested" do
+      get :index, params: { user_id: user, state: :pending }, format: :json
+      pending_orders_json = JSON.parse(pending_orders.to_json(include: :products, methods: :deletable_until))
+      expect(JSON.parse(response.body)).to match_array(pending_orders_json)
+    end
+
+    it "returns final orders when requested" do
+      get :index, params: { user_id: user, state: :final }, format: :json
+      final_orders_json = JSON.parse(final_orders.to_json(include: :products, methods: :deletable_until))
+      expect(JSON.parse(response.body)).to match_array(final_orders_json)
+    end
+  end
+end


### PR DESCRIPTION
Implement order API. Allows getting the orders (and products), with optional filtering on status (pending, final or all).

At some point we might want to include pagination for final or all orders, although this is annoying for pending orders.

Closes #166.