### PR TITLE
Fix saved DB schema being inconsistent with migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 # Dotenv for .env file variables
-gem 'dotenv-rails'
+gem "dotenv-rails"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", "~> 6.1"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,7 @@
 ActiveRecord::Schema.define(version: 2022_07_25_163014) do
 
   create_table "barcodes", force: :cascade do |t|
-    t.integer "product_id"
+    t.integer "product_id", null: false
     t.string "code", default: "", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -36,13 +36,13 @@ ActiveRecord::Schema.define(version: 2022_07_25_163014) do
   end
 
   create_table "order_items", force: :cascade do |t|
-    t.integer "order_id"
+    t.integer "order_id", null: false
     t.integer "product_id", null: false
     t.integer "count", default: 0
   end
 
   create_table "orders", force: :cascade do |t|
-    t.integer "user_id"
+    t.integer "user_id", null: false
     t.integer "price_cents"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
       products_count { 1 }
     end
     before(:create) do |order, evaluator|
-      order.order_items << create_list(:order_item, evaluator.products_count, order: order)
+      order.order_items << build_list(:order_item, evaluator.products_count, order: order)
     end
   end
 end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -61,8 +61,9 @@ describe OrderItem do
 
   describe "stock change" do
     let(:product) { create :product }
+    let(:order) { create :order }
     let(:count) { rand 10 }
-    let(:order_item) { build :order_item, product: product, count: count }
+    let(:order_item) { build :order_item, product: product, order: order, count: count }
 
     it "decrements on create" do
       expect { order_item.save }.to change(product, :stock).by(-count)

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -44,7 +44,7 @@ describe Order do
       it "is calculated from order_items" do
         order = build :order, products_count: 0
         sum = (create_list :product, rand(1..10)).map do |p|
-          create(:order_item, order: order, product: p, count: rand(1..5)) do |oi|
+          build(:order_item, order: order, product: p, count: rand(1..5)) do |oi|
             order.order_items << oi
           end
         end


### PR DESCRIPTION
Generating the DB schema from the migrations resulted in a different schema than
the one currently in the repo. Generally, one shouldn't rerun all the
migrations but in this case the schema in the repo is also different from the
one used in production.

The different schema resulted in a few tests failing, due to null constraints
that were added not being used correctly.

This PR updates both the schema to be consistent with what is used in
production and updates the tests so that they don't fail due to these added
constraints. (It also fixes a linting error added recently.)