### PR TITLE
add recent beverages endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ To provide a consistent experience on every system, docker and docker-compose is
 1. Install [asdf](http://asdf-vm.com/guide/getting-started.html#getting-started)
 2. Install dependencies: `asdf install`
 3. Install gems: `bundle install`
-4. Migrate the db using `bundle exec rails db:migrate`
-5. Seed the db using `bundle exec rails db:seed`
-6. Start Tap by running `bundle exec rails s`
+4. Run: `yarn`
+5. Migrate the db using `bundle exec rails db:migrate`
+6. Seed the db using `bundle exec rails db:seed`
+7. Start Tap by running `bundle exec rails s`
 
 ## Production
 

--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class PublicController < ApplicationController
+  include ApplicationHelper
+  include OrderSessionHelper
+
+  skip_before_action :authenticate_user_from_token!, only: :recent_beverages
+  skip_before_action :authenticate_user!, only: :recent_beverages
+
+  def recent_beverages
+    orders = Order.recent_beverages
+    mapped_orders = orders.joins(:order_items => :product).map do |order|
+      order.order_items.map do |order_item|
+        product = order_item.product
+        {
+          order_id: order.id,
+          order_created_at: order.created_at,
+          product_name: product.name,
+          product_category: product.category
+        }
+      end
+    end.flatten
+
+    render json: mapped_orders
+  end
+end

--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -21,6 +21,6 @@ class PublicController < ApplicationController
       end
     end.flatten
 
-    render json: mapped_orders
+    render json: { orders: mapped_orders }
   end
 end

--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -4,11 +4,11 @@ class PublicController < ApplicationController
   include ApplicationHelper
   include OrderSessionHelper
 
-  skip_before_action :authenticate_user_from_token!, only: :recent_beverages
-  skip_before_action :authenticate_user!, only: :recent_beverages
+  skip_before_action :authenticate_user_from_token!, only: :recent
+  skip_before_action :authenticate_user!, only: :recent
 
-  def recent_beverages
-    orders = Order.recent_beverages
+  def recent
+    orders = Order.recent
     mapped_orders = orders.joins(:order_items => :product).map do |order|
       order.order_items.map do |order_item|
         product = order_item.product

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -34,9 +34,7 @@ class Order < ApplicationRecord
   scope :pending, -> { where(created_at: Rails.application.config.call_api_after.ago..) }
   scope :final, -> { where(created_at: ..Rails.application.config.call_api_after.ago) }
 
-  scope :from_last_two_weeks, -> { where(created_at: 2.weeks.ago..Time.zone.now) }
-  scope :with_category, ->(category) { joins(:products).where(products: { category: category }).distinct }
-  scope :recent_beverages, -> { from_last_two_weeks.with_category("beverages") }
+  scope :recent, -> { where(created_at: 2.weeks.ago..Time.zone.now) }
 
   def to_sentence
     order_items.map do |oi|

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -34,6 +34,10 @@ class Order < ApplicationRecord
   scope :pending, -> { where(created_at: Rails.application.config.call_api_after.ago..) }
   scope :final, -> { where(created_at: ..Rails.application.config.call_api_after.ago) }
 
+  scope :from_last_two_weeks, -> { where(created_at: 2.weeks.ago..Time.zone.now) }
+  scope :with_category, ->(category) { joins(:products).where(products: { category: category }).distinct }
+  scope :recent_beverages, -> { from_last_two_weeks.with_category("beverages") }
+
   def to_sentence
     order_items.map do |oi|
       pluralize(oi.count, oi.product.name)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,8 @@ Rails.application.routes.draw do
   # Koelkast overview page
   get "overview" => "orders#overview", as: "orders"
 
+  get "recent_beverages" => "public#recent_beverages", as: "recent_beverages"
+
   # Guest endpoints
   namespace :guest do
     resources :orders, only: [:new, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,7 +58,7 @@ Rails.application.routes.draw do
   # Koelkast overview page
   get "overview" => "orders#overview", as: "orders"
 
-  get "recent_beverages" => "public#recent_beverages", as: "recent_beverages"
+  get "recent" => "public#recent", as: "recent"
 
   # Guest endpoints
   namespace :guest do


### PR DESCRIPTION
Adds an unauthorized endpoint that returns all recent transactions for beverages.
For each order it returns the 
- order_id
- order_created_at
- product_name
- product_category
Only orders made within the last 2 weeks are returned.

Will be used for a visual for the amount of soft drinks consumed vs mate